### PR TITLE
Version 0.7.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
         'no-empty-function': ['error', { 'allow': ['constructors'] }],
         'no-explicit-any': ['off'],
         'no-console': 'warn',
+        'no-unused-private-class-members': ['off'],
       },
     },
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 <!-- https://keepachangelog.com/en/1.0.0/ -->
 
+## [0.7.0]  2022-02-12
+### Added
+- Add SelectItemInfo that contain info about the SelectItem and the alias that it use
+- Column has as() function can be used to export SelectItemInfo
+- Expression also has as() function
+- Add new option `addAsBeforeColumnAlias?: 'always'|'never'`
+- OrderBy Expression
+- OrderBy helper function o() to create OrderByItemInfo class
+### Fixed
+- ASTERISK, DISTINCT & ALL uses Symbol for better identification
+- BuilderOption refactored by moving it to a new separate file
+- Column name always produced with double quote around them
+- Table name always produced with double quote around them
+- Typo in Table class rename getColumn() to getColumns()
+- Bug in when "addNulls" & "addAsc" options set to "never"
+
 ## [0.6.1]  2022-01-31
-### fixed
+### Fixed
 - export DISTINCT & ALL 
 
 ## [0.6.0]  2022-01-30

--- a/README.md
+++ b/README.md
@@ -23,25 +23,49 @@ const sql = new sedk.Builder(schema)
 
 const stmt1 = sql.select(name, age).from(Employee).where(name.eq('John'), AND, age.gt(25)).getSQL()
 console.log(stmt1)
-// "SELECT name, age FROM Employee WHERE (name = 'John' AND age > 25);"
+// SELECT "name", "age" FROM Employee WHERE ("name" = 'John' AND "age" > 25);
 
 // also it can be written as
 const stmt2 = sql.select(name, age).from(Employee).where(name.eq('John')).and(age.gt(25)).getSQL()
 console.log(stmt2)
-// "SELECT name, age FROM Employee WHERE name = 'John' AND age > 25;"
+// SELECT "name", "age" FROM Employee WHERE "name" = 'John' AND "age" > 25;
 
 
 const bindObj = sql.select(name, age).from(Employee).where(name.eq$('John'), AND, age.gt$(25)).getPostgresqlBinding()
 console.log(bindObj)
 /*
 {
-  sql: 'SELECT name, age FROM Employee WHERE (name = $1 AND age > $2);',
+  sql: 'SELECT "name", "age" FROM Employee WHERE ("name" = $1 AND "age" > $2);',
   values: ['john', 25],
 }
 */
 ```
 
 ## What is New
+### Version: 0.7.0
+- Table & column name always has double quote around their names
+- Column can have an alias
+```typescript
+sql.select(name, age.as('Employee Age')).from(Employee).getSQL()
+// SELECT "name", "age" AS "Employee Age" FROM "Employee";
+```
+- New Builder Option
+```typescript
+{
+  addAsBeforeColumnAlias: 'always'|'never'
+}
+```
+- OrderBy Expression
+```typescript
+sql.selectAsteriskFrom(Employee).orderBy(e(age, ADD, salary)).getSQL()
+// SELECT * FROM "Employee" ORDER BY ("age" + "salary");
+```
+- OrderBy using helper function o()
+```typescript
+sql.selectAsteriskFrom(Employee).orderBy(o(age, DESC, NULLS_FIRST)).getSQL()
+// SELECT * FROM "Employee" ORDER BY "age" DESC NULLS_FIRST;
+```
+
 ### Version: 0.6.0
 - OrderBy now support ASC, DESC, NULLS FIRST and NULLS LAST
 ```typescript
@@ -60,8 +84,8 @@ sql.select(DISTINCT, name, age).from(Employee).getSQL()
 - New Builder Option
 ```typescript
 {
-  addAscAfterOrderByItem?: 'always'|'never'|'when mentioned'
-  addNullsLastAfterOrderByItem?: 'always'|'never'|'when mentioned'
+  addAscAfterOrderByItem: 'always'|'never'|'when mentioned'
+  addNullsLastAfterOrderByItem: 'always'|'never'|'when mentioned'
 }
 ```
 

--- a/doc/Types.puml
+++ b/doc/Types.puml
@@ -35,6 +35,11 @@ mindmapDiagram {
 *** Expression <<class>>
 ** Asterisk <<class>>
 
+* OrderByItem <<type>>
+** Column <<class>>
+** Expression <<class>>
+** string <<primitive>>
+
 * OperandType <<type>>
 ** Expression <<class>>
 ** ValueType <<type>>

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -9,6 +9,8 @@ import {
   ComparisonOperator,
   Operator,
 } from './operators'
+import { OrderByDirection, OrderByItemInfo, OrderByNullsPosition } from './orderBy'
+import { OrderByItem } from './steps'
 
 export function e(left: OperandType): Expression
 export function e(left: BooleanLike, operator: ComparisonOperator, right: BooleanLike|TextBoolean): Condition
@@ -20,4 +22,8 @@ export function e(left: OperandType, operator?: Operator, right?: OperandType): 
     return new Expression(left, operator, right)
   else
     return new Expression(left)
+}
+
+export function o(alias: OrderByItem, direction?: OrderByDirection, nullsPosition?: OrderByNullsPosition): OrderByItemInfo {
+  return new OrderByItemInfo(alias, direction, nullsPosition)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { Builder } from './builder'
 export { ASTERISK, DISTINCT, ALL } from './singletoneConstants'
 export { LogicalOperator } from './steps'
-export { e } from './functions'
+export { e, o } from './functions'
 export {
   ComparisonOperator,
   ArithmeticOperator,

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,0 +1,23 @@
+export type BuilderOption = {
+  useSemicolonAtTheEnd?: boolean
+  addAscAfterOrderByItem?: 'always'|'never'|'when mentioned'
+  addNullsLastAfterOrderByItem?: 'always'|'never'|'when mentioned'
+  addAsBeforeColumnAlias?: 'always'|'never'
+}
+
+const defaultOption: BuilderOption = {
+  useSemicolonAtTheEnd: true,
+  addAscAfterOrderByItem: 'when mentioned',
+  addNullsLastAfterOrderByItem: 'when mentioned',
+  addAsBeforeColumnAlias: 'always',
+}
+Object.freeze(defaultOption)
+
+export function fillUndefinedOptionsWithDefault(option: BuilderOption): BuilderOption {
+  const result: BuilderOption = {}
+  result.useSemicolonAtTheEnd = option.useSemicolonAtTheEnd ?? defaultOption.useSemicolonAtTheEnd
+  result.addAscAfterOrderByItem = option.addAscAfterOrderByItem ?? defaultOption.addAscAfterOrderByItem
+  result.addNullsLastAfterOrderByItem = option.addNullsLastAfterOrderByItem ?? defaultOption.addNullsLastAfterOrderByItem
+  result.addAsBeforeColumnAlias = option.addAsBeforeColumnAlias ?? defaultOption.addAsBeforeColumnAlias
+  return result
+}

--- a/src/orderBy.ts
+++ b/src/orderBy.ts
@@ -1,0 +1,64 @@
+import { BuilderOption } from './option'
+import { OrderByItem } from './steps'
+
+export class OrderByItemInfo {
+  public set builderOption(option: BuilderOption) {
+    this.option = option
+  }
+
+  constructor(
+    private readonly orderByItem: OrderByItem,
+    private readonly direction: OrderByDirection = OrderByDirection.NOT_EXIST,
+    private readonly nullPosition: OrderByNullsPosition = OrderByNullsPosition.NOT_EXIST,
+    private option?: BuilderOption,
+  ) {}
+
+  public toString(): string {
+    const direction = this.getDirectionFromOption()
+    const nullPosition = this.getNullLastFromOption()
+    return `${this.orderByItem}${direction}${nullPosition}`
+  }
+
+  private getDirectionFromOption(): OrderByDirection {
+    if (this.direction === OrderByDirection.DESC)
+      return OrderByDirection.DESC
+
+    if (this.option !== undefined) {
+      switch (this.option.addAscAfterOrderByItem) {
+      case 'always':
+        return OrderByDirection.ASC
+      case 'never':
+        return OrderByDirection.NOT_EXIST
+      }
+    }
+    return this.direction
+  }
+
+  private getNullLastFromOption(): OrderByNullsPosition {
+    if (this.nullPosition === OrderByNullsPosition.NULLS_FIRST)
+      return OrderByNullsPosition.NULLS_FIRST
+
+    if (this.option !== undefined) {
+      switch (this.option.addNullsLastAfterOrderByItem) {
+      case 'always':
+        return OrderByNullsPosition.NULLS_LAST
+      case 'never':
+        return OrderByNullsPosition.NOT_EXIST
+      }
+    }
+    return this.nullPosition
+  }
+}
+
+export enum OrderByDirection {
+  NOT_EXIST = '',
+  ASC = ' ASC', /** default in postgres */
+  DESC = ' DESC',
+}
+
+export enum OrderByNullsPosition {
+  NOT_EXIST = '',
+  NULLS_FIRST = ' NULLS FIRST',
+  NULLS_LAST = ' NULLS LAST', /** default in postgres */
+}
+

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,0 +1,38 @@
+import { BuilderOption } from './option'
+import { SelectItem } from './steps'
+import { Column } from './schema'
+import { Expression } from './models'
+import { escapeDoubleQuote } from './util'
+
+export class SelectItemInfo {
+  public set builderOption(option: BuilderOption) {
+    this.option = option
+  }
+
+  constructor(
+    private readonly selectItem: SelectItem,
+    public readonly alias?: string,
+    private option?: BuilderOption,
+  ) {}
+
+  public getColumns(): Column[] {
+    if (this.selectItem instanceof Column) {
+      return [this.selectItem]
+    } else if (this.selectItem instanceof Expression) {
+      return this.selectItem.getColumns()
+    }
+    return []
+  }
+
+  public toString(): string {
+    if (this.alias !== undefined) {
+      // escape double quote by repeating it
+      const escapedAlias = escapeDoubleQuote(this.alias)
+      const asString = (this.option?.addAsBeforeColumnAlias === 'always')
+        ? ' AS' : ''
+      return `${this.selectItem}${asString} "${escapedAlias}"`
+    }
+    return `${this.selectItem}`
+  }
+
+}

--- a/src/singletoneConstants.ts
+++ b/src/singletoneConstants.ts
@@ -1,5 +1,6 @@
 export class Asterisk {
   private static instance: Asterisk
+  private readonly unique: symbol = Symbol()
 
   private constructor() {}
 
@@ -19,6 +20,7 @@ export const ASTERISK = Asterisk.getInstance()
 
 export class Distinct {
   private static instance: Distinct
+  private readonly unique: symbol = Symbol()
 
   private constructor() {}
 
@@ -38,6 +40,7 @@ export const DISTINCT = Distinct.getInstance()
 
 export class All {
   private static instance: All
+  private readonly unique: symbol = Symbol()
 
   private constructor() {}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,3 @@
+export function escapeDoubleQuote(source:string): string {
+  return source.replace(/"/g, '""')
+}

--- a/test/diffOptions.test.ts
+++ b/test/diffOptions.test.ts
@@ -2,10 +2,11 @@ import { Builder, Database, Table, TextColumn } from '../src'
 
 describe('test Options', () => {
   const column1 = new TextColumn('col1')
+  const column2 = new TextColumn('col2')
 
   const table = new Table(
     'testTable',
-    [column1],
+    [column1, column2],
   )
   const db = new Database([table], 1)
 
@@ -13,31 +14,31 @@ describe('test Options', () => {
     const sqlWithoutSemicolon = new Builder(db, { useSemicolonAtTheEnd: false })
     const sqlWithSemicolon = new Builder(db, { useSemicolonAtTheEnd: true })
     const sqlDefault = new Builder(db)
-    it('Produces [SELECT 1 FROM testTable] without semicolon', () => {
+    it('Produces [SELECT 1 FROM "testTable"] without semicolon', () => {
       const actual = sqlWithoutSemicolon
         .select(1)
         .from(table)
         .getSQL()
 
-      expect(actual).toEqual('SELECT 1 FROM testTable')
+      expect(actual).toEqual('SELECT 1 FROM "testTable"')
     })
 
-    it('Produces [SELECT 1 FROM testTable] without semicolon;', () => {
+    it('Produces [SELECT 1 FROM "testTable"] without semicolon;', () => {
       const actual = sqlWithSemicolon
         .select(1)
         .from(table)
         .getSQL()
 
-      expect(actual).toEqual('SELECT 1 FROM testTable;')
+      expect(actual).toEqual('SELECT 1 FROM "testTable";')
     })
 
-    it('Produces [SELECT 1 FROM testTable] without semicolon; (default)', () => {
+    it('Produces [SELECT 1 FROM "testTable"] without semicolon; (default)', () => {
       const actual = sqlDefault
         .select(1)
         .from(table)
         .getSQL()
 
-      expect(actual).toEqual('SELECT 1 FROM testTable;')
+      expect(actual).toEqual('SELECT 1 FROM "testTable";')
     })
   })
 
@@ -46,74 +47,84 @@ describe('test Options', () => {
     const sqlNever = new Builder(db, { addAscAfterOrderByItem: 'never' })
     const sqlWhenMentioned = new Builder(db, { addAscAfterOrderByItem: 'when mentioned' })
     const sqlDefault = new Builder(db)
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1 ASC;] option(always)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;] option(always)', () => {
       const actual = sqlAlways
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1 ASC;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(never)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(never)', () => {
       const actual = sqlNever
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(never) even asc mentioned', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1", "col2" DESC;] option(never)', () => {
+      const actual = sqlNever
+        .select(column1)
+        .from(table)
+        .orderBy(column1, column2.desc)
+        .getSQL()
+
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1", "col2" DESC;')
+    })
+
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(never) even asc mentioned', () => {
       const actual = sqlNever
         .select(column1)
         .from(table)
         .orderBy(column1.asc)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1 ASC;] option(when mentioned)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;] option(when mentioned)', () => {
       const actual = sqlWhenMentioned
         .select(column1)
         .from(table)
         .orderBy(column1.asc)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1 ASC;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(when mentioned)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(when mentioned)', () => {
       const actual = sqlWhenMentioned
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(Default)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(Default)', () => {
       const actual = sqlDefault
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1 ASC;] option(Default)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;] option(Default)', () => {
       const actual = sqlDefault
         .select(column1)
         .from(table)
         .orderBy(column1.asc)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1 ASC;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;')
     })
   })
 
@@ -122,74 +133,116 @@ describe('test Options', () => {
     const sqlNever = new Builder(db, { addNullsLastAfterOrderByItem: 'never' })
     const sqlWhenMentioned = new Builder(db, { addNullsLastAfterOrderByItem: 'when mentioned' })
     const sqlDefault = new Builder(db)
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1 NULLS LAST;] option(always)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" NULLS LAST;] option(always)', () => {
       const actual = sqlAlways
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1 NULLS LAST;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" NULLS LAST;')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(never)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(never)', () => {
       const actual = sqlNever
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(never) even nulls last mentioned', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" NULLS FIRST ;] option(never)', () => {
+      const actual = sqlNever
+        .select(column1)
+        .from(table)
+        .orderBy(column1.nullsFirst)
+        .getSQL()
+
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" NULLS FIRST;')
+    })
+
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(never) even nulls last mentioned', () => {
       const actual = sqlNever
         .select(column1)
         .from(table)
         .orderBy(column1.nullsLast)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1 ASC;] option(when mentioned)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;] option(when mentioned)', () => {
       const actual = sqlWhenMentioned
         .select(column1)
         .from(table)
         .orderBy(column1.asc)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1 ASC;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" ASC;')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(when mentioned)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(when mentioned)', () => {
       const actual = sqlWhenMentioned
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1;] option(Default)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1";] option(Default)', () => {
       const actual = sqlDefault
         .select(column1)
         .from(table)
         .orderBy(column1)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1";')
     })
 
-    it('Produces [SELECT col1 FROM testTable ORDER BY col1 NULLS LAST;] option(Default)', () => {
+    it('Produces [SELECT "col1" FROM "testTable" ORDER BY "col1" NULLS LAST;] option(Default)', () => {
       const actual = sqlDefault
         .select(column1)
         .from(table)
         .orderBy(column1.nullsLast)
         .getSQL()
 
-      expect(actual).toEqual('SELECT col1 FROM testTable ORDER BY col1 NULLS LAST;')
+      expect(actual).toEqual('SELECT "col1" FROM "testTable" ORDER BY "col1" NULLS LAST;')
+    })
+  })
+
+  describe('test SelectItems AS Option', () => {
+    const sqlAlways = new Builder(db, { addAsBeforeColumnAlias: 'always' })
+    const sqlNever = new Builder(db, { addAsBeforeColumnAlias: 'never' })
+    const sqlDefault = new Builder(db)
+    it('Produces [SELECT "col1" AS "C1" FROM "testTable";] option(always)', () => {
+      const actual = sqlAlways
+        .select(column1.as('C1'))
+        .from(table)
+        .getSQL()
+
+      expect(actual).toEqual('SELECT "col1" AS "C1" FROM "testTable";')
+    })
+
+    it('Produces [SELECT "col1" FROM "testTable";] option(never)', () => {
+      const actual = sqlNever
+        .select(column1.as('C1'))
+        .from(table)
+        .getSQL()
+
+      expect(actual).toEqual('SELECT "col1" "C1" FROM "testTable";')
+    })
+
+    it('Produces [SELECT "col1" AS "C1" FROM "testTable";] option(default)', () => {
+      const actual = sqlDefault
+        .select(column1.as('C1'))
+        .from(table)
+        .getSQL()
+
+      expect(actual).toEqual('SELECT "col1" AS "C1" FROM "testTable";')
     })
   })
 })

--- a/test/distinctStep.test.ts
+++ b/test/distinctStep.test.ts
@@ -18,73 +18,69 @@ describe('test orderBy Step', () => {
   const db = new Database([table], 1)
   const sql = new Builder(db)
 
-  it('Produces [SELECT DISTINCT col1, col2 FROM testTable;]', () => {
-    const actual = sql
-      .selectDistinct(column1, column2)
-      .from(table)
-      .getSQL()
-
-    expect(actual).toEqual('SELECT DISTINCT col1, col2 FROM testTable;')
-  })
-
-  it('Produces [SELECT ALL col1, col2 FROM testTable;]', () => {
-    const actual = sql
-      .selectAll(column1, column2)
-      .from(table)
-      .getSQL()
-
-    expect(actual).toEqual('SELECT ALL col1, col2 FROM testTable;')
-  })
-
-  it('Produces [SELECT DISTINCT col1, col2 FROM testTable;] using select first param', () => {
-    const actual = sql
-      .select(DISTINCT, column1, column2)
-      .from(table)
-      .getSQL()
-
-    expect(actual).toEqual('SELECT DISTINCT col1, col2 FROM testTable;')
-  })
-
-  it('Produces [SELECT ALL col1, col2 FROM testTable;] using select first param', () => {
-    const actual = sql
-      .select(ALL, column1, column2)
-      .from(table)
-      .getSQL()
-
-    expect(actual).toEqual('SELECT ALL col1, col2 FROM testTable;')
-  })
-
-  it('Produces [SELECT ALL FROM testTable;] only ALL is valid (as param)', () => {
-    const actual = sql
-      .select(ALL)
-      .from(table)
-      .getSQL()
-
-    expect(actual).toEqual('SELECT ALL FROM testTable;')
-  })
-
-  it('Produces [SELECT ALL FROM testTable;] only ALL is valid (using selectAll())', () => {
+  /* In Postgres it is allowed to have FROM directly
+   after SELECT with or without ALL
+   */
+  it('Produces [SELECT ALL FROM "testTable";]', () => {
     const actual = sql
       .selectAll()
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT ALL FROM testTable;')
+    expect(actual).toEqual('SELECT ALL FROM "testTable";')
   })
 
-  it('Throws error when param to select passed', () => {
-    function actual() {
-      sql.select().from(table)
-    }
+  it('Produces [SELECT DISTINCT "col1", "col2" FROM "testTable";]', () => {
+    const actual = sql
+      .selectDistinct(column1, column2)
+      .from(table)
+      .getSQL()
 
-    expect(actual).toThrowError(/^Select step must have at least one parameter$/)
+    expect(actual).toEqual('SELECT DISTINCT "col1", "col2" FROM "testTable";')
   })
 
-  it('Throws error when no param to select passed after DISTINCT', () => {
-    function actual() {
-      sql.select(DISTINCT).from(table)
-    }
+  it('Produces [SELECT ALL "col1", "col2" FROM "testTable";]', () => {
+    const actual = sql
+      .selectAll(column1, column2)
+      .from(table)
+      .getSQL()
 
-    expect(actual).toThrow(/^Select step must have at least one parameter after DISTINCT$/)
+    expect(actual).toEqual('SELECT ALL "col1", "col2" FROM "testTable";')
+  })
+
+  it('Produces [SELECT DISTINCT "col1", "col2" FROM "testTable";] using select first param', () => {
+    const actual = sql
+      .select(DISTINCT, column1, column2)
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT DISTINCT "col1", "col2" FROM "testTable";')
+  })
+
+  it('Produces [SELECT ALL "col1", "col2" FROM "testTable";] using select first param', () => {
+    const actual = sql
+      .select(ALL, column1, column2)
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT ALL "col1", "col2" FROM "testTable";')
+  })
+
+  it('Produces [SELECT ALL FROM "testTable";] only ALL is valid (as param)', () => {
+    const actual = sql
+      .select(ALL)
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT ALL FROM "testTable";')
+  })
+
+  it('Produces [SELECT ALL FROM "testTable";] only ALL is valid (using selectAll())', () => {
+    const actual = sql
+      .selectAll()
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT ALL FROM "testTable";')
   })
 })

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,0 +1,85 @@
+import {
+  Builder,
+  BooleanColumn,
+  ColumnNotFoundError,
+  Database,
+  e,
+  NumberColumn,
+  Table,
+  TableNotFoundError,
+  TextColumn,
+  InvalidExpressionError,
+  ArithmeticOperator,
+  ComparisonOperator,
+  DISTINCT,
+} from '../src'
+
+//Alias
+const ADD = ArithmeticOperator.ADD
+const GT = ComparisonOperator.GreaterThan
+
+describe('Throw desired Errors', () => {
+  // database schema
+  const column1 = new TextColumn('col1')
+  const column2 = new TextColumn('col2')
+  const column3 = new TextColumn('col3')
+  const column4 = new NumberColumn('col4')
+  const column5 = new NumberColumn('col5')
+  const column6 = new NumberColumn('col6')
+  const column7 = new BooleanColumn('col7')
+  const column8 = new BooleanColumn('col8')
+  const table = new Table(
+    'testTable',
+    [column1, column2, column3, column4, column5, column6, column7, column8],
+  )
+  const db = new Database([table], 1)
+  const sql = new Builder(db)
+
+  it('Throws error when add invalid operator', () => {
+    function actual() {
+      sql.select(e(1, GT, 'f'))
+    }
+
+    expect(actual).toThrowError('You can not have "NUMBER" and "TEXT" with operator ">"')
+    expect(actual).toThrowError(InvalidExpressionError)
+  })
+
+  it('Throws error when column not exist', () => {
+    const wrongColumn = new TextColumn('wrongColumn')
+
+    function actual() {
+      sql.select(column1, wrongColumn, column3)
+    }
+
+    expect(actual).toThrowError('Column: "wrongColumn" not found')
+    expect(actual).toThrowError(ColumnNotFoundError)
+  })
+
+  it('Throws error when table not exist', () => {
+    const wrongTable = new Table('wrongTable', [new TextColumn('anyColumn')])
+
+    function actual() {
+      sql.select(column1).from(wrongTable)
+    }
+
+    expect(actual).toThrowError('Table: "wrongTable" not found')
+    expect(actual).toThrowError(TableNotFoundError)
+  })
+
+  it('Throws error if number added to text', () => {
+    function actual() {
+      sql.select(e(1, ADD, 'a')).getSQL()
+    }
+
+    expect(actual).toThrowError('You can not have "NUMBER" and "TEXT" with operator "+"')
+    expect(actual).toThrowError(InvalidExpressionError)
+  })
+
+  it('Throws error when no param to select passed after DISTINCT', () => {
+    function actual() {
+      sql.select(DISTINCT).from(table)
+    }
+
+    expect(actual).toThrow(/^Select step must have at least one parameter after DISTINCT$/)
+  })
+})

--- a/test/general.test.ts
+++ b/test/general.test.ts
@@ -45,75 +45,121 @@ describe('test from one table', () => {
   const db = new Database([table], 1)
   const sql = new Builder(db)
 
-  it('Produces [SELECT col1 FROM testTable;]', () => {
+  /* In Postgres it is ok to have FROM directly after SELECT */
+  it('Produces [SELECT FROM "testTable";]', () => {
+    const actual = sql
+      .select()
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT FROM "testTable";')
+  })
+
+  it('Produces [SELECT "col1" FROM "testTable";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable";')
   })
 
-  it('Produces [SELECT * FROM testTable;]', () => {
+  it('Produces [SELECT "col1" AS "C1" FROM "testTable";]', () => {
+    const actual = sql
+      .select(column1.as('C1'))
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT "col1" AS "C1" FROM "testTable";')
+  })
+
+  it('Produces [SELECT "col1" AS "C""1" FROM "testTable";] (escape double quote)', () => {
+    const actual = sql
+      .select(column1.as('C"1'))
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT "col1" AS "C""1" FROM "testTable";')
+  })
+
+  it('Produces [SELECT * FROM "testTable";]', () => {
     const actual = sql
       .select(ASTERISK)
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT * FROM testTable;')
+    expect(actual).toEqual('SELECT * FROM "testTable";')
   })
 
-  it('Produces [SELECT * FROM testTable;] using selectAsteriskFrom()', () => {
+  it('Produces [SELECT * FROM "testTable";] using selectAsteriskFrom()', () => {
     const actual = sql
       .selectAsteriskFrom(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT * FROM testTable;')
+    expect(actual).toEqual('SELECT * FROM "testTable";')
   })
 
-  it('Produces [SELECT 1 FROM testTable;]', () => {
+  it('Produces [SELECT 1 FROM "testTable";]', () => {
     const actual = sql
       .select(e(1))
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT 1 FROM testTable;')
+    expect(actual).toEqual('SELECT 1 FROM "testTable";')
   })
 
-  it("Produces [SELECT 'a' FROM testTable;]", () => {
+  it('Produces [SELECT 1 AS "One" FROM "testTable";]', () => {
+    const actual = sql
+      .select(e(1).as('One'))
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT 1 AS "One" FROM "testTable";')
+  })
+
+  it("Produces [SELECT 'a' FROM \"testTable\";]", () => {
     const actual = sql
       .select(e('a'))
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual("SELECT 'a' FROM testTable;")
+    expect(actual).toEqual("SELECT 'a' FROM \"testTable\";")
   })
 
-  it("Produces [SELECT *, NULL, 'a', '*', 1, TRUE, FALSE, -5, 3.14 FROM testTable;]", () => {
+  it("Produces [SELECT *, NULL, 'a', '*', 1, TRUE, FALSE, -5, 3.14 FROM \"testTable\";]", () => {
     const actual = sql
       .select(ASTERISK, null, 'a', '*', 1, true, false, -5, 3.14)
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual("SELECT *, NULL, 'a', '*', 1, TRUE, FALSE, -5, 3.14 FROM testTable;")
+    expect(actual).toEqual("SELECT *, NULL, 'a', '*', 1, TRUE, FALSE, -5, 3.14 FROM \"testTable\";")
   })
 
-  it("Produces [SELECT ('a' || 'b') FROM testTable;]", () => {
+  it("Produces [SELECT ('a' || 'b') FROM \"testTable\";]", () => {
     const actual = sql
       .select(e('a', CONCAT, 'b'))
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual("SELECT ('a' || 'b') FROM testTable;")
+    expect(actual).toEqual("SELECT ('a' || 'b') FROM \"testTable\";")
   })
 
-  it('Produces [SELECT (1 + (2 - 3)) FROM testTable;]', () => {
+  it('Produces [SELECT (1 + (2 - 3)) FROM "testTable";]', () => {
     const actual = sql
       .select(e(1, ADD, e(2, SUB, 3)))
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT (1 + (2 - 3)) FROM testTable;')
+    expect(actual).toEqual('SELECT (1 + (2 - 3)) FROM "testTable";')
+  })
+
+  it('Produces [SELECT (1 + (2 - 3)) AS "Calc" FROM "testTable";]', () => {
+    const actual = sql
+      .select(e(1, ADD, e(2, SUB, 3)).as('Calc'))
+      .from(table)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT (1 + (2 - 3)) AS "Calc" FROM "testTable";')
   })
 
   describe('select literal values', () => {
@@ -124,36 +170,46 @@ describe('test from one table', () => {
 
   })
 
-  it('Produces [SELECT col1, col2 FROM testTable;]', () => {
+  it('Produces [SELECT "col1", "col2" FROM "testTable";]', () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col2 FROM testTable;')
+    expect(actual).toEqual('SELECT "col1", "col2" FROM "testTable";')
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
       .where(column1.eq('x'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 <> 'x';]", () => {
+  it('Produces [SELECT "col1" AS "C1", "col2" AS "C2" FROM "testTable" WHERE "col1" = \'x\';]', () => {
+    const actual = sql
+      .select(column1.as('C1'), column2.as('C2'))
+      .from(table)
+      .where(column1.eq('x'))
+      .getSQL()
+
+    expect(actual).toEqual('SELECT "col1" AS "C1", "col2" AS "C2" FROM "testTable" WHERE "col1" = \'x\';')
+  })
+
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" <> 'x';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
       .where(column1.ne('x'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 <> 'x';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" <> 'x';")
   })
 
-  it('Produces [SELECT col1, col2 FROM testTable WHERE col1 = $1;]', () => {
+  it('Produces [SELECT "col1", "col2" FROM "testTable" WHERE "col1" = $1;]', () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -161,14 +217,14 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col2 FROM testTable WHERE col1 = $1;',
+      sql: 'SELECT "col1", "col2" FROM "testTable" WHERE "col1" = $1;',
       values: ['x'],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col2 FROM testTable WHERE col1 <> $1;]', () => {
+  it('Produces [SELECT "col1", "col2" FROM "testTable" WHERE "col1" <> $1;]', () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -176,24 +232,24 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col2 FROM testTable WHERE col1 <> $1;',
+      sql: 'SELECT "col1", "col2" FROM "testTable" WHERE "col1" <> $1;',
       values: ['x'],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 = 5;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" = 5;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
       .where(column4.eq(5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col4 FROM testTable WHERE col4 = 5;')
+    expect(actual).toEqual('SELECT "col1", "col4" FROM "testTable" WHERE "col4" = 5;')
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 = $1;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" = $1;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
@@ -201,24 +257,24 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col4 FROM testTable WHERE col4 = $1;',
+      sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" = $1;',
       values: [5],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 <> 5;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" <> 5;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
       .where(column4.ne(5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col4 FROM testTable WHERE col4 <> 5;')
+    expect(actual).toEqual('SELECT "col1", "col4" FROM "testTable" WHERE "col4" <> 5;')
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 <> $1;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" <> $1;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
@@ -226,33 +282,33 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col4 FROM testTable WHERE col4 <> $1;',
+      sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" <> $1;',
       values: [5],
     }
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 IS NULL;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NULL;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
       .where(column4.eq(null))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col4 FROM testTable WHERE col4 IS NULL;')
+    expect(actual).toEqual('SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NULL;')
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 IS NOT NULL;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT NULL;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
       .where(column4.ne(null))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col4 FROM testTable WHERE col4 IS NOT NULL;')
+    expect(actual).toEqual('SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT NULL;')
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 IS NOT $1;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT $1;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
@@ -260,33 +316,33 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col4 FROM testTable WHERE col4 IS NOT $1;',
+      sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT $1;',
       values: [null],
     }
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col1 IS NULL;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS NULL;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
       .where(column1.eq(null))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col4 FROM testTable WHERE col1 IS NULL;')
+    expect(actual).toEqual('SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS NULL;')
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col1 IS NOT NULL;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS NOT NULL;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
       .where(column1.ne(null))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1, col4 FROM testTable WHERE col1 IS NOT NULL;')
+    expect(actual).toEqual('SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS NOT NULL;')
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 IS $1;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS $1;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
@@ -294,14 +350,14 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col4 FROM testTable WHERE col4 IS $1;',
+      sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS $1;',
       values: [null],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col4 IS NOT $1;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT $1;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
@@ -309,14 +365,14 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col4 FROM testTable WHERE col4 IS NOT $1;',
+      sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT $1;',
       values: [null],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1, col4 FROM testTable WHERE col1 IS $1;]', () => {
+  it('Produces [SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS $1;]', () => {
     const actual = sql
       .select(column1, column4)
       .from(table)
@@ -324,24 +380,24 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col4 FROM testTable WHERE col1 IS $1;',
+      sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS $1;',
       values: [null],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' );]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' );]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
       .where(column1.eq('x'), AND, column2.eq('y'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' );")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' );")
   })
 
-  it('Produces [SELECT col1, col2 FROM testTable WHERE ( col1 = $1 AND col2 = $2 );]', () => {
+  it('Produces [SELECT "col1", "col2" FROM "testTable" WHERE ( "col1" = $1 AND "col2" = $2 );]', () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -349,24 +405,24 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1, col2 FROM testTable WHERE ( col1 = $1 AND col2 = $2 );',
+      sql: 'SELECT "col1", "col2" FROM "testTable" WHERE ( "col1" = $1 AND "col2" = $2 );',
       values: ['x', 'y'],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' OR col2 = 'y' );]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' OR \"col2\" = 'y' );]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
       .where(column1.eq('x'), OR, column2.eq('y'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' OR col2 = 'y' );")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' OR \"col2\" = 'y' );")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x' AND col2 = 'y';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' AND \"col2\" = 'y';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -374,10 +430,10 @@ describe('test from one table', () => {
       .and(column2.eq('y'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x' AND col2 = 'y';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' AND \"col2\" = 'y';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' OR col2 = 'y' ) AND col3 = 'z';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' OR \"col2\" = 'y' ) AND \"col3\" = 'z';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -385,10 +441,10 @@ describe('test from one table', () => {
       .and(column3.eq('z'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' OR col2 = 'y' ) AND col3 = 'z';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' OR \"col2\" = 'y' ) AND \"col3\" = 'z';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x' OR col2 = 'y';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' OR \"col2\" = 'y';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -396,10 +452,10 @@ describe('test from one table', () => {
       .or(column2.eq('y'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x' OR col2 = 'y';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' OR \"col2\" = 'y';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' ) OR col3 = 'z';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' ) OR \"col3\" = 'z';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -407,10 +463,10 @@ describe('test from one table', () => {
       .or(column3.eq('z'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' ) OR col3 = 'z';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' ) OR \"col3\" = 'z';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' ) AND col3 = 'z1' OR col3 = 'z2';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' ) AND \"col3\" = 'z1' OR \"col3\" = 'z2';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -419,10 +475,10 @@ describe('test from one table', () => {
       .or(column3.eq('z2'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' ) AND col3 = 'z1' OR col3 = 'z2';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' ) AND \"col3\" = 'z1' OR \"col3\" = 'z2';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x' AND col2 = 'y' AND col3 = 'z';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' AND \"col2\" = 'y' AND \"col3\" = 'z';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -431,10 +487,10 @@ describe('test from one table', () => {
       .and(column3.eq('z'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x' AND col2 = 'y' AND col3 = 'z';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' AND \"col2\" = 'y' AND \"col3\" = 'z';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x' OR col2 = 'y' OR col3 = 'z';]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' OR \"col2\" = 'y' OR \"col3\" = 'z';]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -443,10 +499,10 @@ describe('test from one table', () => {
       .or(column3.eq('z'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x' OR col2 = 'y' OR col3 = 'z';")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x' OR \"col2\" = 'y' OR \"col3\" = 'z';")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x1  x2' AND ( col2 = 'y' OR col3 = 'z' );]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x1  x2' AND ( \"col2\" = 'y' OR \"col3\" = 'z' );]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -454,10 +510,10 @@ describe('test from one table', () => {
       .and(column2.eq('y'), OR, column3.eq('z'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x1  x2' AND ( col2 = 'y' OR col3 = 'z' );")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x1  x2' AND ( \"col2\" = 'y' OR \"col3\" = 'z' );")
   })
 
-  it("Produces [SELECT col1, col2 FROM testTable WHERE col1 = 'x1  x2' OR ( col2 = 'y' AND col3 = 'z' );]", () => {
+  it("Produces [SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x1  x2' OR ( \"col2\" = 'y' AND \"col3\" = 'z' );]", () => {
     const actual = sql
       .select(column1, column2)
       .from(table)
@@ -465,20 +521,20 @@ describe('test from one table', () => {
       .or(column2.eq('y'), AND, column3.eq('z'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1, col2 FROM testTable WHERE col1 = 'x1  x2' OR ( col2 = 'y' AND col3 = 'z' );")
+    expect(actual).toEqual("SELECT \"col1\", \"col2\" FROM \"testTable\" WHERE \"col1\" = 'x1  x2' OR ( \"col2\" = 'y' AND \"col3\" = 'z' );")
   })
 
-  it("Produces [SELECT col1 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' OR col4 = 5 );]", () => {
+  it("Produces [SELECT \"col1\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' OR \"col4\" = 5 );]", () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column1.eq('x'), AND, column2.eq('y'), OR, column4.eq(5))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1 FROM testTable WHERE ( col1 = 'x' AND col2 = 'y' OR col4 = 5 );")
+    expect(actual).toEqual("SELECT \"col1\" FROM \"testTable\" WHERE ( \"col1\" = 'x' AND \"col2\" = 'y' OR \"col4\" = 5 );")
   })
 
-  it("Produces [SELECT col1 FROM testTable WHERE col1 = 'x' AND ( col2 = 'y' OR col3 = 'z' OR col4 = 5 );]", () => {
+  it("Produces [SELECT \"col1\" FROM \"testTable\" WHERE \"col1\" = 'x' AND ( \"col2\" = 'y' OR \"col3\" = 'z' OR \"col4\" = 5 );]", () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -486,10 +542,10 @@ describe('test from one table', () => {
       .and(column2.eq('y'), OR, column3.eq('z'), OR, column4.eq(5))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1 FROM testTable WHERE col1 = 'x' AND ( col2 = 'y' OR col3 = 'z' OR col4 = 5 );")
+    expect(actual).toEqual("SELECT \"col1\" FROM \"testTable\" WHERE \"col1\" = 'x' AND ( \"col2\" = 'y' OR \"col3\" = 'z' OR \"col4\" = 5 );")
   })
 
-  it("Produces [SELECT col1 FROM testTable WHERE col1 = 'x' OR ( col2 = 'y' AND col3 = 'z' AND col4 = 5 );]", () => {
+  it("Produces [SELECT \"col1\" FROM \"testTable\" WHERE \"col1\" = 'x' OR ( \"col2\" = 'y' AND \"col3\" = 'z' AND \"col4\" = 5 );]", () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -497,10 +553,10 @@ describe('test from one table', () => {
       .or(column2.eq('y'), AND, column3.eq('z'), AND, column4.eq(5))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1 FROM testTable WHERE col1 = 'x' OR ( col2 = 'y' AND col3 = 'z' AND col4 = 5 );")
+    expect(actual).toEqual("SELECT \"col1\" FROM \"testTable\" WHERE \"col1\" = 'x' OR ( \"col2\" = 'y' AND \"col3\" = 'z' AND \"col4\" = 5 );")
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col1 = $1 OR ( col2 = $2 AND col3 = $3 AND col4 = $4 );]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col1" = $1 OR ( "col2" = $2 AND "col3" = $3 AND "col4" = $4 );]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -509,24 +565,24 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col1 = $1 OR ( col2 = $2 AND col3 = $3 AND col4 = $4 );',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col1" = $1 OR ( "col2" = $2 AND "col3" = $3 AND "col4" = $4 );',
       values: ['x', 'y', 'z', 5],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 > 5;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" > 5;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.gt(5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 > 5;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" > 5;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 > $1;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" > $1;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -534,23 +590,23 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col4 > $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col4" > $1;',
       values: [5],
     }
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 < 5;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" < 5;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.lt(5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 < 5;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" < 5;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 < $1;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" < $1;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -558,23 +614,23 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col4 < $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col4" < $1;',
       values: [5],
     }
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 >= 5;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" >= 5;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.ge(5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 >= 5;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" >= 5;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 >= $1;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" >= $1;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -582,23 +638,23 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col4 >= $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col4" >= $1;',
       values: [5],
     }
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 <= 5;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" <= 5;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.le(5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 <= 5;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" <= 5;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 <= $1;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" <= $1;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -606,110 +662,110 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col4 <= $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col4" <= $1;',
       values: [5],
     }
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col1 = col2;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col1" = "col2";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column1.eq(column2))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col1 = col2;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col1" = "col2";')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 + col6);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" + "col6");]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, ADD, column6))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 + col6);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" + "col6");')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 - col6);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" - "col6");]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, SUB, column6))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 - col6);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" - "col6");')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 - 1);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" - 1);]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, SUB, 1))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 - 1);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" - 1);')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 * 1);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" * 1);]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, MUL, 1))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 * 1);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" * 1);')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 / 1);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" / 1);]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, DIV, 1))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 / 1);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" / 1);')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 % 1);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" % 1);]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, MOD, 1))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 % 1);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" % 1);')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (col5 ^ 1);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" ^ 1);]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5, EXP, 1))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (col5 ^ 1);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = ("col5" ^ 1);')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (1 + col5);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = (1 + "col5");]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(1, ADD, column5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (1 + col5);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = (1 + "col5");')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = (1 + 1);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = (1 + 1);]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(1, ADD, 1))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = (1 + 1);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = (1 + 1);')
   })
 
   describe('Throw desired Errors', () => {
@@ -729,7 +785,7 @@ describe('test from one table', () => {
         sql.select(column1, wrongColumn, column3)
       }
 
-      expect(actual).toThrowError('Column: wrongColumn not found')
+      expect(actual).toThrowError('Column: "wrongColumn" not found')
       expect(actual).toThrowError(ColumnNotFoundError)
     })
 
@@ -740,7 +796,7 @@ describe('test from one table', () => {
         sql.select(column1).from(wrongTable)
       }
 
-      expect(actual).toThrowError('Table: wrongTable not found')
+      expect(actual).toThrowError('Table: "wrongTable" not found')
       expect(actual).toThrowError(TableNotFoundError)
     })
 
@@ -754,37 +810,37 @@ describe('test from one table', () => {
     })
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 > col5;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" > "col5";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.gt(column5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 > col5;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" > "col5";')
   })
 
-  it("Produces [SELECT col1 FROM testTable WHERE (col7 > 'tru');]", () => {
+  it("Produces [SELECT \"col1\" FROM \"testTable\" WHERE (\"col7\" > 'tru');]", () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(e(column7, GT, 'tru'))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1 FROM testTable WHERE (col7 > 'tru');")
+    expect(actual).toEqual("SELECT \"col1\" FROM \"testTable\" WHERE (\"col7\" > 'tru');")
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col4 = col5;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col4" = "col5";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column4.eq(column5))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col4 = col5;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col4" = "col5";')
   })
 
-  it("Produces [SELECT col1 FROM testTable WHERE col2 = 'value contain single quote '' and more '''' , ''';]", () => {
+  it("Produces [SELECT \"col1\" FROM \"testTable\" WHERE \"col2\" = 'value contain single quote '' and more '''' , ''';]", () => {
     const stringContainSingleQuote = "value contain single quote ' and more '' , '"
     const actual = sql
       .select(column1)
@@ -792,30 +848,30 @@ describe('test from one table', () => {
       .where(column2.eq(stringContainSingleQuote))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1 FROM testTable WHERE col2 = 'value contain single quote '' and more '''' , ''';")
+    expect(actual).toEqual("SELECT \"col1\" FROM \"testTable\" WHERE \"col2\" = 'value contain single quote '' and more '''' , ''';")
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 = TRUE;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" = TRUE;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.eq(true))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7 = TRUE;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7" = TRUE;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 <> TRUE;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" <> TRUE;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.ne(true))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7 <> TRUE;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7" <> TRUE;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 = $1;] for [$1=true]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" = $1;] for [$1=true]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -823,14 +879,14 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col7 = $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col7" = $1;',
       values: [true],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 <> $1;] for [$1=true]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" <> $1;] for [$1=true]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -838,14 +894,14 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col7 <> $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col7" <> $1;',
       values: [true],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 IS $1;] for [$1=null]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" IS $1;] for [$1=null]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -853,14 +909,14 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col7 IS $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col7" IS $1;',
       values: [null],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 IS NOT $1;] for [$1=null]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" IS NOT $1;] for [$1=null]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -868,44 +924,44 @@ describe('test from one table', () => {
       .getPostgresqlBinding()
 
     const expected = {
-      sql: 'SELECT col1 FROM testTable WHERE col7 IS NOT $1;',
+      sql: 'SELECT "col1" FROM "testTable" WHERE "col7" IS NOT $1;',
       values: [null],
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7)
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7";')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE NOT col7;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE NOT "col7";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.not())
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE NOT col7;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE NOT "col7";')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE (NOT col7 OR NOT col8);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE (NOT "col7" OR NOT "col8");]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.not(), OR, column8.not())
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE ( NOT col7 OR NOT col8 );')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE ( NOT "col7" OR NOT "col8" );')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE NOT col7 AND NOT col8;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE NOT "col7" AND NOT "col8";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
@@ -913,66 +969,66 @@ describe('test from one table', () => {
       .and(column8.not())
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE NOT col7 AND NOT col8;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE NOT "col7" AND NOT "col8";')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 = FALSE;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" = FALSE;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.eq(false))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7 = FALSE;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7" = FALSE;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 = col8;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" = "col8";]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.eq(column8))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7 = col8;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7" = "col8";')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 IS NULL;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" IS NULL;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.eq(null))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7 IS NULL;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7" IS NULL;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col7 IS NOT NULL;]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col7" IS NOT NULL;]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column7.ne(null))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col7 IS NOT NULL;')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col7" IS NOT NULL;')
   })
 
-  it('Produces [SELECT col1 FROM testTable WHERE col1 = (col2 || col3);]', () => {
+  it('Produces [SELECT "col1" FROM "testTable" WHERE "col1" = ("col2" || "col3");]', () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column1.eq(column2.concat(column3)))
       .getSQL()
 
-    expect(actual).toEqual('SELECT col1 FROM testTable WHERE col1 = (col2 || col3);')
+    expect(actual).toEqual('SELECT "col1" FROM "testTable" WHERE "col1" = ("col2" || "col3");')
   })
 
-  it("Produces [SELECT col1 FROM testTable WHERE col1 = (col2 || 'something');]", () => {
+  it("Produces [SELECT \"col1\" FROM \"testTable\" WHERE \"col1\" = (\"col2\" || 'something');]", () => {
     const actual = sql
       .select(column1)
       .from(table)
       .where(column1.eq(column2.concat('something')))
       .getSQL()
 
-    expect(actual).toEqual("SELECT col1 FROM testTable WHERE col1 = (col2 || 'something');")
+    expect(actual).toEqual("SELECT \"col1\" FROM \"testTable\" WHERE \"col1\" = (\"col2\" || 'something');")
   })
 })

--- a/test/orderByStep.test.ts
+++ b/test/orderByStep.test.ts
@@ -1,12 +1,5 @@
-import {
-  Builder,
-  BooleanColumn,
-  Database,
-  NumberColumn,
-  Table,
-  TextColumn,
-} from '../src'
-
+import { ArithmeticOperator, BooleanColumn, Builder, Database, e, NumberColumn, o, Table, TextColumn } from '../src'
+import { OrderByDirection, OrderByNullsPosition } from '../src/orderBy'
 
 describe('test orderBy Step', () => {
   // database schema
@@ -25,39 +18,97 @@ describe('test orderBy Step', () => {
   const db = new Database([table], 1)
   const sql = new Builder(db)
 
-  it('Produces [SELECT * FROM testTable ORDER BY col1, col2;]', () => {
+  it('Produces [SELECT * FROM "testTable" ORDER BY "col1", "col2";]', () => {
     const actual = sql
       .selectAsteriskFrom(table)
       .orderBy(column1, column2)
       .getSQL()
 
-    expect(actual).toEqual('SELECT * FROM testTable ORDER BY col1, col2;')
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY "col1", "col2";')
   })
 
-  it('Produces [SELECT * FROM testTable ORDER BY col1 ASC, col2 DESC;]', () => {
+  it('Produces [SELECT * FROM "testTable" ORDER BY ("col4" + "col5");]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .orderBy(e(column4, ArithmeticOperator.ADD, column5))
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY ("col4" + "col5");')
+  })
+
+  it('Produces [SELECT * FROM "testTable" ORDER BY col1 DESC NULLS FIRST;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .orderBy(o(column1, OrderByDirection.DESC, OrderByNullsPosition.NULLS_FIRST))
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY "col1" DESC NULLS FIRST;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" ORDER BY col1 ASC;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .orderBy(o(column1, OrderByDirection.DESC, OrderByNullsPosition.NULLS_FIRST))
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY "col1" DESC NULLS FIRST;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" ORDER BY ("col4" + "col5") DESC;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .orderBy(o(e(column4, ArithmeticOperator.ADD, column5), OrderByDirection.DESC))
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY ("col4" + "col5") DESC;')
+  })
+
+  it('Produces [SELECT ("col4" + "col5") AS "Col:4+5" FROM "testTable" ORDER BY "Col:4+5";]', () => {
+    const actual = sql
+      .select(e(column4, ArithmeticOperator.ADD, column5).as('Col:4+5'))
+      .from(table)
+      .orderBy('Col:4+5')
+      .getSQL()
+
+    expect(actual).toEqual('SELECT ("col4" + "col5") AS "Col:4+5" FROM "testTable" ORDER BY "Col:4+5";')
+  })
+
+  it('Throws error when ORDER BY alias not exist', () => {
+    function actual() {
+      sql
+        .select(column1.as('A'))
+        .from(table)
+        .orderBy('B')
+        .getSQL()
+    }
+
+    expect(actual).toThrowError('Alias B is not exist, if this is a column, then it should be entered as Column class')
+  })
+
+  it('Produces [SELECT * FROM "testTable" ORDER BY "col1" ASC, "col2" DESC;]', () => {
     const actual = sql
       .selectAsteriskFrom(table)
       .orderBy(column1.asc, column2.desc)
       .getSQL()
 
-    expect(actual).toEqual('SELECT * FROM testTable ORDER BY col1 ASC, col2 DESC;')
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY "col1" ASC, "col2" DESC;')
   })
 
-  it('Produces [SELECT * FROM testTable ORDER BY col1 ASC, col2 DESC, col3 NULLS FIRST, col4 NULLS LAST;]', () => {
+  it('Produces [SELECT * FROM "testTable" ORDER BY "col1" ASC, "col2" DESC, "col3" NULLS FIRST, "col4" NULLS LAST;]', () => {
     const actual = sql
       .selectAsteriskFrom(table)
       .orderBy(column1.asc, column2.desc, column3.nullsFirst, column4.nullsLast)
       .getSQL()
 
-    expect(actual).toEqual('SELECT * FROM testTable ORDER BY col1 ASC, col2 DESC, col3 NULLS FIRST, col4 NULLS LAST;')
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY "col1" ASC, "col2" DESC, "col3" NULLS FIRST, "col4" NULLS LAST;')
   })
 
-  it('Produces [SELECT * FROM testTable ORDER BY col1 ASC NULLS FIRST, col2 DESC NULLS FIRST, col3 ASC NULLS LAST, col4 DESC NULLS LAST;]', () => {
+  it('Produces [SELECT * FROM "testTable" ORDER BY "col1" ASC NULLS FIRST, "col2" DESC NULLS FIRST, "col3" ASC NULLS LAST, "col4" DESC NULLS LAST;]', () => {
     const actual = sql
       .selectAsteriskFrom(table)
       .orderBy(column1.ascNullsFirst, column2.descNullsFirst, column3.ascNullsLast, column4.descNullsLast)
       .getSQL()
 
-    expect(actual).toEqual('SELECT * FROM testTable ORDER BY col1 ASC NULLS FIRST, col2 DESC NULLS FIRST, col3 ASC NULLS LAST, col4 DESC NULLS LAST;')
+    expect(actual).toEqual('SELECT * FROM "testTable" ORDER BY "col1" ASC NULLS FIRST, "col2" DESC NULLS FIRST, "col3" ASC NULLS LAST, "col4" DESC NULLS LAST;')
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "sourceMap": true,
     "outDir": "dist",
     "strictNullChecks": true,
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": false,
+    "strictFunctionTypes": true,
   },
   "lib": [
     "es2015"


### PR DESCRIPTION
### Added
- Add SelectItemInfo that contain info about the SelectItem and the alias that it use
- Column has as() function can be used to export SelectItemInfo
- Expression also has as() function
- Add new option `addAsBeforeColumnAlias?: 'always'|'never'`
- OrderBy Expression
- OrderBy helper function o() to create OrderByItemInfo class
### Fixed
- ASTERISK, DISTINCT & ALL uses Symbol for better identification
- BuilderOption refactored by moving it to a new separate file
- Column name always produced with double quote around them
- Table name always produced with double quote around them
- Typo in Table class rename getColumn() to getColumns()
- Bug in when "addNulls" & "addAsc" options set to "never"