### PR TITLE
Version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 <!-- https://keepachangelog.com/en/1.0.0/ -->
 
+## [0.8.0]  2022-02-16
+### Added
+- Add LIMIT and OFFSET steps
+- Add LIMIT$ and OFFSET& for binds values
+### Breaking Changes
+- cleanUp() only called when select step called from builder
+- cleanUp() never call automatically when calling getSQL() or getPostgresqlBinding()
+- rename getPostgresqlBinding() to getBinds()
+
 ## [0.7.1]  2022-02-14
 ### Added
 - Flex arg for OrderBy step, now you can add DESC, ASC, NULLS_FIRST... as argument with columns and aliases

--- a/README.md
+++ b/README.md
@@ -31,22 +31,37 @@ console.log(stmt2)
 // SELECT "name", "age" FROM Employee WHERE "name" = 'John' AND "age" > 25;
 
 
-const bindObj = sql.select(name, age).from(Employee).where(name.eq$('John'), AND, age.gt$(25)).getPostgresqlBinding()
+const bindObj = sql.select(name, age).from(Employee).where(name.eq$('John'), AND, age.gt$(25)).getBinds()
 console.log(bindObj)
 /*
 {
   sql: 'SELECT "name", "age" FROM Employee WHERE ("name" = $1 AND "age" > $2);',
   values: ['john', 25],
 }
-*/
+ */
 ```
 
 ## What is New
+### Version: 0.8.0
+- LIMIT & OFFSET steps
+```typescript
+sql.selectAsteriskFrom(Employee).limit(50).offset(10).getSQL()
+// SELECT * FROM "Employee" LIMIT 50 OFFSET 10;
+
+sql.selectAsteriskFrom(Employee).limit$(50).offset$(10).getBinds()
+/*
+{
+  sql: 'SELECT * FROM "Employee" LIMIT $1 OFFSET $2',
+  values: [50, 10],
+}
+ */
+```
+
 ### Version: 0.7.1
 - ASC, DESC, NULLS_FIRST and NULLS_LAST can be added in OrderBy step
 ```typescript
 sql.selectAsteriskFrom(Employee).orderBy(column1, ASC, NULLS_FIRST).getSQL()
-// SELECT * FROM "Employee" ORDER BY "col1" ASC NULLS FIRST;;
+// SELECT * FROM "Employee" ORDER BY "col1" ASC NULLS FIRST;
 ```
 ### Version: 0.7.0
 - Table & column name always has double quote around their names

--- a/doc/RailRoad.md
+++ b/doc/RailRoad.md
@@ -2,4 +2,7 @@
 RailRoad diagram generated using https://www.bottlecaps.de/rr/ui
 
 ### Steps Grammar: 
-`SEDK      ::= Builder ( ( 'SELECT' | 'SELECT_ALL' | 'SELECT_DISTINCT' ) 'FROM' | 'SELECT_ASTERISK_FROM' ) ( 'WHERE' ( 'AND' | 'OR' )* )? 'ORDER BY'?`
+```
+SEDK ::= Builder ( ( 'SELECT' | 'SELECT_ALL' | 'SELECT_DISTINCT' ) 'FROM' | 'SELECT_ASTERISK_FROM' ) 
+( 'WHERE' ( 'AND' | 'OR' )* )? 'ORDER BY'? 'LIMIT'? 'OFFSET'?
+```

--- a/doc/StepsRailRoad.svg
+++ b/doc/StepsRailRoad.svg
@@ -1,36 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="837" height="247">
+<svg xmlns="http://www.w3.org/2000/svg" width="1089" height="247">
     <defs>
         <style type="text/css">
             @namespace "http://www.w3.org/2000/svg";
-            .line {fill: none; stroke: #001133; stroke-width: 1;}
-            .bold-line {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
-            .thin-line {stroke: #000A1F; shape-rendering: crispEdges}
-            .filled {fill: #001133; stroke: none;}
-            text.terminal {font-family: Verdana, Sans-serif;
+
+            .line {
+            fill: none;
+            stroke: #001133;
+            stroke-width: 1;
+            }
+
+            .bold-line {
+            stroke: #000714;
+            shape-rendering: crispEdges;
+            stroke-width: 2;
+            }
+
+            .thin-line {
+            stroke: #000A1F;
+            shape-rendering: crispEdges
+            }
+
+            .filled {
+            fill: #001133;
+            stroke: none;
+            }
+
+            text.terminal {
+            font-family: Verdana, Sans-serif;
             font-size: 12px;
             fill: #000714;
             font-weight: bold;
             }
-            text.nonterminal {font-family: Verdana, Sans-serif;
+
+            text.nonterminal {
+            font-family: Verdana, Sans-serif;
             font-size: 12px;
             fill: #00091A;
             font-weight: normal;
             }
-            text.regexp {font-family: Verdana, Sans-serif;
+
+            text.regexp {
+            font-family: Verdana, Sans-serif;
             font-size: 12px;
             fill: #000A1F;
             font-weight: normal;
             }
-            rect, circle, polygon {fill: #001133; stroke: #001133;}
-            rect.terminal {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
-            rect.nonterminal {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
-            rect.text {fill: none; stroke: none;}
-            polygon.regexp {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+
+            rect,
+            circle,
+            polygon {
+            fill: #001133;
+            stroke: #001133;
+            }
+
+            rect.terminal {
+            fill: #4D88FF;
+            stroke: #001133;
+            stroke-width: 1;
+            }
+
+            rect.nonterminal {
+            fill: #9EBFFF;
+            stroke: #001133;
+            stroke-width: 1;
+            }
+
+            rect.text {
+            fill: none;
+            stroke: none;
+            }
+
+            polygon.regexp {
+            fill: #C7DAFF;
+            stroke: #001133;
+            stroke-width: 1;
+            }
         </style>
     </defs>
     <polygon points="9 95 1 91 1 99"/>
     <polygon points="17 95 9 91 9 99"/>
-    <a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Builder" xlink:title="Builder">
+    <a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Builder"
+       xlink:title="Builder">
         <rect x="31" y="81" width="64" height="32"/>
         <rect x="29" y="79" width="64" height="32" class="nonterminal"/>
         <text class="nonterminal" x="39" y="99">Builder</text>
@@ -62,8 +112,14 @@
     <rect x="699" y="113" width="90" height="32" rx="10"/>
     <rect x="697" y="111" width="90" height="32" class="terminal" rx="10"/>
     <text class="terminal" x="707" y="131">ORDER BY</text>
+    <rect x="849" y="113" width="60" height="32" rx="10"/>
+    <rect x="847" y="111" width="60" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="857" y="131">LIMIT</text>
+    <rect x="969" y="113" width="72" height="32" rx="10"/>
+    <rect x="967" y="111" width="72" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="977" y="131">OFFSET</text>
     <path xmlns:svg="http://www.w3.org/2000/svg" class="line"
-          d="m17 95 h2 m0 0 h10 m64 0 h10 m40 0 h10 m70 0 h10 m0 0 h76 m-186 0 h20 m166 0 h20 m-206 0 q10 0 10 10 m186 0 q0 -10 10 -10 m-196 10 v24 m186 0 v-24 m-186 24 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m104 0 h10 m0 0 h42 m-176 -10 v20 m186 0 v-20 m-186 20 v24 m186 0 v-24 m-186 24 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m146 0 h10 m20 -88 h10 m60 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v112 m306 0 v-112 m-306 112 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m196 0 h10 m0 0 h70 m40 -132 h10 m70 0 h10 m20 0 h10 m0 0 h58 m-88 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m68 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-68 0 h10 m48 0 h10 m-78 10 l0 -44 q0 -10 10 -10 m78 54 l0 -44 q0 -10 -10 -10 m-68 0 h10 m40 0 h10 m0 0 h8 m-198 78 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v14 m218 0 v-14 m-218 14 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m0 0 h188 m40 -34 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -32 h-3"/>
-    <polygon points="827 95 835 91 835 99"/>
-    <polygon points="827 95 819 91 819 99"/>
+          d="m17 95 h2 m0 0 h10 m64 0 h10 m40 0 h10 m70 0 h10 m0 0 h76 m-186 0 h20 m166 0 h20 m-206 0 q10 0 10 10 m186 0 q0 -10 10 -10 m-196 10 v24 m186 0 v-24 m-186 24 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m104 0 h10 m0 0 h42 m-176 -10 v20 m186 0 v-20 m-186 20 v24 m186 0 v-24 m-186 24 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m146 0 h10 m20 -88 h10 m60 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v112 m306 0 v-112 m-306 112 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m196 0 h10 m0 0 h70 m40 -132 h10 m70 0 h10 m20 0 h10 m0 0 h58 m-88 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m68 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-68 0 h10 m48 0 h10 m-78 10 l0 -44 q0 -10 10 -10 m78 54 l0 -44 q0 -10 -10 -10 m-68 0 h10 m40 0 h10 m0 0 h8 m-198 78 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v14 m218 0 v-14 m-218 14 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m0 0 h188 m40 -34 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m40 -32 h10 m0 0 h70 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v12 m100 0 v-12 m-100 12 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m60 0 h10 m40 -32 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m23 -32 h-3"/>
+    <polygon points="1079 95 1087 91 1087 99"/>
+    <polygon points="1079 95 1071 91 1071 99"/>
 </svg>

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -21,12 +21,21 @@ export class BinderStore {
   }
 
   public getValues(): PrimitiveType[] {
-    const result = this.store.map(it => it.value)
+    return this.store.map(it => it.value)
+  }
+
+  public cleanUp() {
     this.store.length = 0
-    return result
   }
 }
 
 export class Binder {
-  public constructor(public readonly no: number, public readonly value: PrimitiveType) {}
+  public constructor(
+    public readonly no: number,
+    public readonly value: PrimitiveType
+  ) {}
+
+  public toString(): string {
+    return `$${this.no}`
+  }
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 import { Database, Table } from './schema'
 import { Condition } from './models'
-import { BinderStore } from './binder'
+import { Binder, BinderStore } from './binder'
 import { ASTERISK, Distinct, All } from './singletoneConstants'
 import {
   Step,
@@ -18,14 +18,17 @@ import { BuilderOption, fillUndefinedOptionsWithDefault } from './option'
 
 export type BuilderData = {
   dbSchema: Database,
-  //TODO: make table array ot another kind of collection object when we add leftOperand inner join step
-  table?: Table,
+  option: BuilderOption,
+  /** Below data used to generate SQL statment */
   selectItemInfos: SelectItemInfo[],
+  //TODO: make table "FromItemInfo" array
+  table?: Table,
   distinct: ''|' DISTINCT'|' ALL'
   whereParts: (LogicalOperator|Condition|Parenthesis)[],
   orderByItemInfos: OrderByItemInfo[],
+  limit?: null|number|Binder|All,
+  offset?: number|Binder,
   binderStore: BinderStore,
-  option: BuilderOption,
 }
 
 export class Builder {

--- a/src/models.ts
+++ b/src/models.ts
@@ -95,7 +95,7 @@ export class Operand {
     if (this.value === null) {
       return 'NULL'
     } else if (this.value instanceof Binder) {
-      return `$${this.value.no}`
+      return `${this.value}`
     } else if (typeof this.value === 'string') {
       // escape single quote by repeating it
       const escapedValue = this.value.replace(/'/g, '\'\'')

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -146,4 +146,24 @@ describe('Throw desired Errors', () => {
 
     expect(actual).toThrow(/^ DESC shouldn't come after "ASC" or "DESC" without column or alias in between$/)
   })
+
+  it('Throws error when LIMIT step has negative number', () => {
+    function actual() {
+      sql
+        .selectAsteriskFrom(table)
+        .limit(-1)
+    }
+
+    expect(actual).toThrow(/^Invalid limit value -1, negative numbers are not allowed$/)
+  })
+
+  it('Throws error when OFFSET step has negative number', () => {
+    function actual() {
+      sql
+        .selectAsteriskFrom(table)
+        .offset(-1)
+    }
+
+    expect(actual).toThrow(/^Invalid offset value -1, negative numbers are not allowed$/)
+  })
 })

--- a/test/general.test.ts
+++ b/test/general.test.ts
@@ -214,7 +214,7 @@ describe('test from one table', () => {
       .select(column1, column2)
       .from(table)
       .where(column1.eq$('x'))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col2" FROM "testTable" WHERE "col1" = $1;',
@@ -229,7 +229,7 @@ describe('test from one table', () => {
       .select(column1, column2)
       .from(table)
       .where(column1.ne$('x'))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col2" FROM "testTable" WHERE "col1" <> $1;',
@@ -254,7 +254,7 @@ describe('test from one table', () => {
       .select(column1, column4)
       .from(table)
       .where(column4.eq$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" = $1;',
@@ -279,7 +279,7 @@ describe('test from one table', () => {
       .select(column1, column4)
       .from(table)
       .where(column4.ne$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" <> $1;',
@@ -313,7 +313,7 @@ describe('test from one table', () => {
       .select(column1, column4)
       .from(table)
       .where(column4.ne$(null))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT $1;',
@@ -347,7 +347,7 @@ describe('test from one table', () => {
       .select(column1, column4)
       .from(table)
       .where(column4.eq$(null))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS $1;',
@@ -362,7 +362,7 @@ describe('test from one table', () => {
       .select(column1, column4)
       .from(table)
       .where(column4.ne$(null))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col4" IS NOT $1;',
@@ -377,7 +377,7 @@ describe('test from one table', () => {
       .select(column1, column4)
       .from(table)
       .where(column1.eq$(null))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col4" FROM "testTable" WHERE "col1" IS $1;',
@@ -402,7 +402,7 @@ describe('test from one table', () => {
       .select(column1, column2)
       .from(table)
       .where(column1.eq$('x'), AND, column2.eq$('y'))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1", "col2" FROM "testTable" WHERE ( "col1" = $1 AND "col2" = $2 );',
@@ -562,7 +562,7 @@ describe('test from one table', () => {
       .from(table)
       .where(column1.eq$('x'))
       .or(column2.eq$('y'), AND, column3.eq$('z'), AND, column4.eq$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col1" = $1 OR ( "col2" = $2 AND "col3" = $3 AND "col4" = $4 );',
@@ -587,7 +587,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column4.gt$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col4" > $1;',
@@ -611,7 +611,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column4.lt$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col4" < $1;',
@@ -635,7 +635,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column4.ge$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col4" >= $1;',
@@ -659,7 +659,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column4.le$(5))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col4" <= $1;',
@@ -876,7 +876,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column7.eq$(true))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col7" = $1;',
@@ -891,7 +891,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column7.ne$(true))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col7" <> $1;',
@@ -906,7 +906,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column7.eq$(null))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col7" IS $1;',
@@ -921,7 +921,7 @@ describe('test from one table', () => {
       .select(column1)
       .from(table)
       .where(column7.ne$(null))
-      .getPostgresqlBinding()
+      .getBinds()
 
     const expected = {
       sql: 'SELECT "col1" FROM "testTable" WHERE "col7" IS NOT $1;',

--- a/test/limitAndOffsetSteps.test.ts
+++ b/test/limitAndOffsetSteps.test.ts
@@ -1,0 +1,130 @@
+import {
+  Builder,
+  BooleanColumn,
+  Database,
+  NumberColumn,
+  Table,
+  TextColumn,
+  ALL,
+} from '../src'
+
+describe('Test LIMIT and OFFSET Steps', () => {
+  // database schema
+  const column1 = new TextColumn('col1')
+  const column2 = new TextColumn('col2')
+  const column3 = new TextColumn('col3')
+  const column4 = new NumberColumn('col4')
+  const column5 = new NumberColumn('col5')
+  const column6 = new NumberColumn('col6')
+  const column7 = new BooleanColumn('col7')
+  const column8 = new BooleanColumn('col8')
+  const table = new Table(
+    'testTable',
+    [column1, column2, column3, column4, column5, column6, column7, column8],
+  )
+  const db = new Database([table], 1)
+  const sql = new Builder(db)
+
+  it('Produces [SELECT * FROM "testTable" LIMIT 50 OFFSET 10;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit(50)
+      .offset(10)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" LIMIT 50 OFFSET 10;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" LIMIT $1 OFFSET $2;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit$(50)
+      .offset$(10)
+      .getBinds()
+
+    const expected = {
+      sql: 'SELECT * FROM "testTable" LIMIT $1 OFFSET $2;',
+      values: [50, 10],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('Produces [SELECT * FROM "testTable" LIMIT 50;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit(50)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" LIMIT 50;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" LIMIT $1;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit$(50)
+      .getBinds()
+
+    const expected = {
+      sql: 'SELECT * FROM "testTable" LIMIT $1;',
+      values: [50],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('Produces [SELECT * FROM "testTable" LIMIT NULL;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit(null)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" LIMIT NULL;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" LIMIT ALL;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit(ALL)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" LIMIT ALL;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" LIMIT $1;] ($1 = null)', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .limit$(null)
+      .getBinds()
+
+    const expected = {
+      sql: 'SELECT * FROM "testTable" LIMIT $1;',
+      values: [null],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('Produces [SELECT * FROM "testTable" OFFSET 10;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .offset(10)
+      .getSQL()
+
+    expect(actual).toEqual('SELECT * FROM "testTable" OFFSET 10;')
+  })
+
+  it('Produces [SELECT * FROM "testTable" OFFSET $1;]', () => {
+    const actual = sql
+      .selectAsteriskFrom(table)
+      .offset$(10)
+      .getBinds()
+
+    const expected = {
+      sql: 'SELECT * FROM "testTable" OFFSET $1;',
+      values: [10],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
### Added
- Add LIMIT and OFFSET steps
- Add LIMIT$ and OFFSET& for binds values
### Breaking Changes
- cleanUp() only called when select step called from builder
- cleanUp() never call automatically when calling getSQL() or getPostgresqlBinding()
- rename getPostgresqlBinding() to getBinds()